### PR TITLE
Error restructuring

### DIFF
--- a/barcode.go
+++ b/barcode.go
@@ -54,9 +54,9 @@ func NewBarcode(data string) (Barcode, error) {
 
 	bc.DocumentSerial.String, bc.DocumentSerial.Err = extractData(data, BarcodeDataPrefixSerial)
 
-	bc.Dob.DateT, bc.Dob.String, bc.Dob.Err = processDate(data, BarcodeDataPrefixDOB)
+	bc.Dob = processDate(data, BarcodeDataPrefixDOB)
 
-	bc.Expiry.DateT, bc.Expiry.String, bc.Expiry.Err = processDate(data, BarcodeDataPrefixExpiry)
+	bc.Expiry = processDate(data, BarcodeDataPrefixExpiry)
 
 	return bc, nil
 }
@@ -109,13 +109,15 @@ func (bc Barcode) SelectDate(dateType BarcodeDataType, date *time.Time) (*time.T
 }
 
 // processDate extracts the date for the prefix, and return it in *time.Time and as a YYYYMMDD formatted string, and any errors
-func processDate(data string, prefix BarcodeDataPrefix) (*time.Time, string, error) {
+func processDate(data string, prefix BarcodeDataPrefix) DateField {
 	date, err := extractData(data, prefix)
 	if err != nil {
-		return nil, "", err
+		return DateField{
+			Err: err,
+		}
 	}
 	if date == "" {
-		return nil, "", nil
+		return DateField{}
 	}
 
 	fieldName := "uknown"
@@ -131,12 +133,18 @@ func processDate(data string, prefix BarcodeDataPrefix) (*time.Time, string, err
 	dateT, err := parseDate(date, fieldName)
 
 	if err != nil {
-		return nil, "", err
+		return DateField{
+			Err: err,
+		}
 	}
 	// convert to a YYYYMMDD standard format
 	date = dateT.Format(TimeLayoutBarcodeData)
 
-	return dateT, date, nil
+	return DateField{
+		String: date,
+		DateT:  dateT,
+		Err:    nil,
+	}
 }
 
 // parseDate takes in a date and field name strings

--- a/barcode.go
+++ b/barcode.go
@@ -63,7 +63,7 @@ func NewBarcode(data string) (Barcode, error) {
 
 // SelectDate compares the date of the type BarcodeDataType found in the barcode data with a date which is passed in time.Time format.
 // If dates do not match, it returns the barcode date and a ErrBarcodeDateMismatch error, otherwise it returns the original date passed in, and any error.
-// If no barcode date was found it returns the original date passed in, and nil error.
+// If no barcode date was found, it returns the original date passed in, and nil error.
 // Dates are returned in time.Time format
 func (bc Barcode) SelectDate(dateType BarcodeDataType, date *time.Time) (*time.Time, error) {
 	var bcDate string
@@ -108,6 +108,7 @@ func (bc Barcode) SelectDate(dateType BarcodeDataType, date *time.Time) (*time.T
 	return date, nil
 }
 
+// processDate extracts the date for the prefix, and return it in *time.Time and as a YYYYMMDD formatted string, and any errors
 func processDate(data string, prefix BarcodeDataPrefix) (*time.Time, string, error) {
 	date, err := extractData(data, prefix)
 	if err != nil {
@@ -138,6 +139,8 @@ func processDate(data string, prefix BarcodeDataPrefix) (*time.Time, string, err
 	return dateT, date, nil
 }
 
+// parseDate takes in a date and field name strings
+// It will then attempt to convert to a time.Time value and return it with any errors
 func parseDate(date, fieldName string) (*time.Time, error) {
 	_, err := strconv.Atoi(date)
 	if err != nil {
@@ -166,6 +169,7 @@ func parseDate(date, fieldName string) (*time.Time, error) {
 	return &dateT, nil
 }
 
+// extractData extracts the information associated with 'prefix' from 'data' and return the extracted string and any errors
 func extractData(data string, prefix BarcodeDataPrefix) (string, error) {
 	re := regexp.MustCompile(fmt.Sprintf(`\n%s\s*(\S+)`, prefix))
 	match := re.FindStringSubmatch(data)

--- a/drivers_license_test.go
+++ b/drivers_license_test.go
@@ -193,18 +193,18 @@ func TestCompareDate(t *testing.T) {
 	require.True(t, IsDateError(err))
 
 	// should return ErrPrefixExtraction
-	dateT, date, err := processDate("someteststring", BarcodeDataPrefix("foo"))
+	df := processDate("someteststring", BarcodeDataPrefix("foo"))
 	require.NotNil(t, err)
-	require.IsType(t, ErrPrefixExtraction{}, err)
-	if !errors.As(err, &ErrPrefixExtraction{}) {
+	require.IsType(t, ErrPrefixExtraction{}, df.Err)
+	if !errors.As(df.Err, &ErrPrefixExtraction{}) {
 		t.Fatal("invalid error type using errors.As")
 	}
-	require.Nil(t, dateT)
-	require.Empty(t, date)
+	require.Nil(t, df.DateT)
+	require.Empty(t, df.String)
 	require.True(t, IsPackageError(err))
 
 	// should return ErrInvalidDate
-	dateT, err = parseDate("someteststring", "testField")
+	dateT, err := parseDate("someteststring", "testField")
 	require.NotNil(t, err)
 	var errInvDate ErrInvalidDate
 	require.ErrorAs(t, err, &errInvDate)

--- a/drivers_license_test.go
+++ b/drivers_license_test.go
@@ -206,8 +206,9 @@ func TestCompareDate(t *testing.T) {
 	// should return ErrInvalidDate
 	dateT, err = parseDate("someteststring", "testField")
 	require.NotNil(t, err)
-	require.IsType(t, ErrInvalidDate{}, err)
-	require.EqualValues(t, "fieldname: \"testField\" : invalid date", err.Error())
+	var errInvDate ErrInvalidDate
+	require.ErrorAs(t, err, &errInvDate)
+	require.EqualValues(t, "fieldname: \"testField\" : invalid date: \"someteststring\"", err.Error())
 	if !errors.As(err, &ErrInvalidDate{}) {
 		t.Fatal("invalid error type using errors.As")
 	}

--- a/errors.go
+++ b/errors.go
@@ -13,10 +13,11 @@ func (e ErrInvalidData) Error() string {
 
 type ErrInvalidDate struct {
 	FieldName string
+	Value     string
 }
 
 func (e ErrInvalidDate) Error() string {
-	return fmt.Sprintf("fieldname: %q : invalid date", e.FieldName)
+	return fmt.Sprintf("fieldname: %q : invalid date: %q", e.FieldName, e.Value)
 }
 
 type ErrBarcodeDateMismatch struct {
@@ -28,7 +29,8 @@ func (e ErrBarcodeDateMismatch) Error() string {
 }
 
 type ErrPrefixExtraction struct {
-	Prefix BarcodeDataPrefix
+	Prefix      BarcodeDataPrefix
+	IsDateError bool
 }
 
 func (e ErrPrefixExtraction) Error() string {
@@ -53,4 +55,19 @@ func IsPackageError(err error) bool {
 		errors.As(err, &ErrParseDate{}) ||
 		errors.As(err, &ErrInvalidData{}) ||
 		errors.As(err, &ErrInvalidDate{})
+}
+
+func IsDateError(err error) bool {
+	if errors.As(err, &ErrBarcodeDateMismatch{}) ||
+		errors.As(err, &ErrParseDate{}) ||
+		errors.As(err, &ErrInvalidDate{}) {
+		return true
+	}
+
+	var extractErr ErrPrefixExtraction
+	if errors.As(err, &extractErr) && extractErr.IsDateError {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Store errors in the appropriate barcode field for easier inspection by consumers.

Do not fail on first extraction/parse error in NewBarcode(). Instead, extract and parse all that can be and store any errors in the appropriate barcode field. Only fail if the barcode data as a whole is invalid.

Add new convenience method `IsDateError()` to allow consumers to easily determine if an error contains a date related error.

